### PR TITLE
Added in the data/irs/ to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+data/irs/


### PR DESCRIPTION
I will be sending over the .zip for the irs data via slack since github can't handle the size of the files. So, this change is adding in the `data/irs/` path to the .gitignore, so everyone can download it safely.